### PR TITLE
build(sec): Fix CVE-2023-2976 (Google Guava)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ publishing {
         maven(MavenPublication) {
             groupId = 'io.github.bensku'
             artifactId = 'java-ts-bind'
-            version = '1.0.0-jahia-2'
+            version = '1.0.0-jahia-3'
             from components.java
         }
     }
@@ -34,6 +34,7 @@ compileJava {
 
 dependencies {
     implementation 'com.github.javaparser:javaparser-symbol-solver-core:3.22.1'
+    implementation 'com.google.guava:guava:32.0.1-jre' // CVE-2023-2976
     implementation 'com.google.code.gson:gson:2.11.0'
     implementation 'org.jcommander:jcommander:1.83'
     implementation 'org.jsoup:jsoup:1.18.3'


### PR DESCRIPTION
### Description
Use version 32.0.1 of Google Guava that contains a fix for [CVE-2023-2976](https://nvd.nist.gov/vuln/detail/cve-2023-2976), vulnerability [reported by SonarQube](https://sonarqube.jahia.com/project/issues?resolved=false&severities=BLOCKER%2CCRITICAL%2CMAJOR%2CMINOR&types=VULNERABILITY&id=org.jahia.modules%3Ajavascript-modules&open=AZaE42sTZtHrK-5Hu3Fi).
NB: That dependency is pulled transitively by _com.github.javaparser:javaparser-symbol-solver-core_ that is [no longer maintained](https://github.com/javaparser/javasymbolsolver).


> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
